### PR TITLE
Fix Motivation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is not really useful for anything at the moment.
 Inline C &amp; Objective-C in Haskell
 =====================================
 
-This library uses Template Haskell and `language-c-quote`, a quasi-quotation library for C-like languages, to provide inline C and Objective-C in Haskell. It extracts the C/Objective-C code automatically, when compiling the Haskell program, and generates marshalling code for common types. The wiki on GitHub details the [motivation](wiki/Motivation) for this approach.
+This library uses Template Haskell and `language-c-quote`, a quasi-quotation library for C-like languages, to provide inline C and Objective-C in Haskell. It extracts the C/Objective-C code automatically, when compiling the Haskell program, and generates marshalling code for common types. The wiki on GitHub details the [motivation](https://github.com/mchakravarty/language-c-inline/wiki/Motivation) for this approach.
 
 Building
 --------


### PR DESCRIPTION
The current syntax is just broken.
Use a fully-qualified link such that even when the repository is cloned onto one's local hard drive, the link will continue working.
