### PR TITLE
Adapt to language-c-quote-0.11.7.3

### DIFF
--- a/Language/C/Inline/Hint.hs
+++ b/Language/C/Inline/Hint.hs
@@ -14,10 +14,10 @@
 module Language.C.Inline.Hint (
   -- * Annotations
   Annotated(..), (<:), void, annotatedShowQ,
-  
+
   -- * Hints
-  Hint(..), 
-  
+  Hint(..),
+
   -- * Querying of annotated entities
   haskellTypeOf, foreignTypeOf, newForeignPtrOf, stripAnnotation
 ) where
@@ -66,13 +66,13 @@ class Hint hint where
   foreignType       :: hint -> Q (Maybe QC.Type)  -- ^In case of 'Nothing', the foreign type is determined by the Haskell type.
   showQ             :: hint -> Q String
   newForeignPtrName :: hint -> Q (Maybe TH.Name)
-  
+
 instance Hint Name where   -- must be a type name
   haskellType       = conT
   foreignType       = const (return Nothing)
   showQ             = return . show
   newForeignPtrName = const (return Nothing)
-      
+
 instance Hint (Q TH.Type) where
   haskellType       = id
   foreignType       = const (return Nothing)
@@ -87,12 +87,12 @@ haskellTypeOf (Typed name)
   = do
     { info <- reify name
     ; case info of
-        ClassOpI _ ty _ _ -> return ty
-        VarI     _ ty _ _ -> return ty
-        nonVarInfo    -> 
+        ClassOpI _ ty _ -> return ty
+        VarI     _ ty _ -> return ty
+        nonVarInfo    ->
           do
-          { reportErrorAndFail QC.ObjC $ 
-              "expected '" ++ show name ++ "' to be a typed variable name, but it is " ++ 
+          { reportErrorAndFail QC.ObjC $
+              "expected '" ++ show name ++ "' to be a typed variable name, but it is " ++
               show (TH.ppr nonVarInfo)
           }
     }

--- a/Language/C/Inline/TH.hs
+++ b/Language/C/Inline/TH.hs
@@ -14,10 +14,10 @@
 module Language.C.Inline.TH (
   -- * Decompose type expressions
   headTyConName, headTyConNameOrError,
-  
+
   -- * Decompose idiomatic declarations
   foreignWrapperDatacon, ptrOfForeignPtrWrapper, unwrapForeignPtrWrapper
-  
+
 ) where
 
   -- standard libraries
@@ -67,7 +67,7 @@ splitAppTy = split []
 --
 foreignWrapperDatacon :: TH.Type -> Q TH.Exp
 foreignWrapperDatacon ty
-  = do 
+  = do
     { (datacon, _) <- decomposeForeignPtrWrapper ty
     ; return $ ConE datacon
     }
@@ -80,7 +80,7 @@ ptrOfForeignPtrWrapper ty = [t| Ptr $(snd <$> decomposeForeignPtrWrapper ty) |]
 -- |Generate code that unwraps the foreign pointer inside the given foreign pointer wrapper type.
 --
 unwrapForeignPtrWrapper :: TH.Type -> Q TH.Exp
-unwrapForeignPtrWrapper ty 
+unwrapForeignPtrWrapper ty
   = do
     { (datacon, _) <- decomposeForeignPtrWrapper ty
     ; v <- newName "v"
@@ -96,25 +96,25 @@ unwrapForeignPtrWrapper ty
 --
 decomposeForeignPtrWrapper :: TH.Type -> Q (TH.Name, TH.Type)
 decomposeForeignPtrWrapper ty
-  = do 
+  = do
     { let (tycon, args) = splitAppTy ty
     ; name <- case tycon of
                 ConT name -> return name
-                _         -> 
+                _         ->
                   do
-                  { reportErrorAndFail QC.ObjC $ 
+                  { reportErrorAndFail QC.ObjC $
                       "expected '" ++ show tycon ++ "' be a type constructor of a 'ForeignPtr' wrapper"
                   }
 
     ; info <- reify name
     ; case info of
-        TyConI (NewtypeD [] _name tvs (NormalC dataconName [(_strict, ConT fptr `AppT` ptrArg)]) _deriv) 
+        TyConI (NewtypeD [] _name tvs mayKd (NormalC dataconName [(_strict, ConT fptr `AppT` ptrArg)]) _deriv)
           | fptr == ''ForeignPtr
           -> return (dataconName, substitute (zip args tvs) ptrArg)
-        nonForeign -> 
+        nonForeign ->
           do
-          { reportErrorAndFail QC.ObjC $ 
-              "expected '" ++ show name ++ "' to refer to a 'ForeignPtr' wrapped into a newtype, but it is " ++ 
+          { reportErrorAndFail QC.ObjC $
+              "expected '" ++ show name ++ "' to refer to a 'ForeignPtr' wrapped into a newtype, but it is " ++
               show (TH.ppr nonForeign)
           }
     }
@@ -137,13 +137,13 @@ decomposeForeignPtrWrapper ty
       = substituteName subst tv
     substitute _subst ty
       = ty
-    
+
     substituteCxt subst cxt = map (substitute subst) cxt
-    
+
     substituteName []               tv     = VarT tv
     substituteName ((arg, tv):args) thisTv
       | tv `matches` thisTv = arg
       | otherwise           = VarT thisTv
-      
+
     PlainTV  name     `matches` thisTv = name == thisTv
     KindedTV name _ki `matches` thisTv = name == thisTv

--- a/language-c-inline.cabal
+++ b/language-c-inline.cabal
@@ -82,7 +82,7 @@ Library
                         base              >= 4.0 && < 5,
                         containers        >= 0.4,
                         filepath          >= 1.2,
-                        language-c-quote  >= 0.8 && < 0.9,
+                        language-c-quote  >= 0.8 && < 0.12,
                         mainland-pretty   >= 0.2.5,
                         template-haskell
 


### PR DESCRIPTION
Fix some error for adapt language-c-quote-0.11.7.3 package within Haskell lts-8.23(ghc-8.0.2). This change is used to successfully build HaskellSpritekit, the current code is failed build spritekit-0.9.02 in ghc-8.0.2 through cabal.
Sorry for previous PullRequest that select wrong branch.